### PR TITLE
Opening the possibility of newest to oldest ActivityStreams

### DIFF
--- a/docs/spec/api/0.1/recommendations_for_activity_streams.md
+++ b/docs/spec/api/0.1/recommendations_for_activity_streams.md
@@ -144,7 +144,7 @@ __Additional Cached Metadata__<br>In some cases, additional metadata is also cac
 
 A consumer may decide to make a full cache of a dataset of entity metadata.  This is commonly done for several reasons including, but not limited to, increased control over uptime, throughput, and indexing for search.  The cache needs to stay in sync with the source dataset as near to real time as is possible using incremental updates.
 
-To address this use case, the provider creates and makes available a dated list of all new, modified, and deleted entities along with specifics about how the entities have changed.  The consumer can process a stream of change documents, from oldest to newest, that was published since their last incremental update.  Specific details about each change can be used to update the local cache.
+To address this use case, the provider creates and makes available a dated list of all new, modified, and deleted entities along with specifics about how the entities have changed.  The consumer can process a stream of change documents, preferably from oldest to newest, that was published since their last incremental update.  Specific details about each change can be used to update the local cache.
 
 ### 1.3. Terminology
 {: #terminology}
@@ -202,7 +202,7 @@ Reference:  [Ordered Collection][org-w3c-activitystreams-coretype-orderedcollect
 
 Each _Entity Metadata Collection_{:.term} _MUST_{:.strong-term} have at least one Entry Point.  It _MAY_{:.strong-term} have multiple Entry Points to satisfy different use cases.  For example, one Entry Point may provide detailed changes to support incremental updates of a full cache and a second may only provide notifications of primary label changes.
 
-The Entry Point _MUST_{:.strong-term} be implemented as an _Ordered Collection_{:.term} following the definition in the Activity Stream specification.  The key points are repeated here with examples specific to Entity Metadata Management.
+The Entry Point _MUST_{:.strong-term} be implemented as an _Ordered Collection_{:.term} following the definition in the Activity Stream specification. The key points are repeated here with examples specific to Entity Metadata Management.
 
 #### FULL EXAMPLE for Entry Point:
 
@@ -383,7 +383,7 @@ The _Entry Point_{:.term} _MAY_{:.strong-term} have a _totalItems_{:.term} prope
 Reference:  [Ordered Collection Page][org-w3c-activitystreams-coretype-orderedcollectionpage] in the [Activity Stream specification][org-w3c-activitystreams]
 {:.reference}
 
-Each time a set of changes is published, changes _MUST_{:.strong-term} be released in at least one _Change Set_{:.term}.  Changes _MAY_{:.strong-term} be published across multiple _Change Sets_{:.term}.  For example, a site may decide that each _Change Set_{:.term} will have at most 50 changes and if that maximum is exceeded during the release time period, then a second _Change Set_{:.term} will be created. All changes within a _Change Set_{:.term} and, if applicable, across  Change Sets _MUST_{:.strong-term} be sorted in date-time order in the _orderedItems_{:.term} property with the earliest change in the set appearing first and most recent change in the set appearing last.
+Each time a set of changes is published, changes _MUST_{:.strong-term} be released in at least one _Change Set_{:.term}.  Changes _MAY_{:.strong-term} be published across multiple _Change Sets_{:.term}.  For example, a site may decide that each _Change Set_{:.term} will have at most 50 changes and if that maximum is exceeded during the release time period, then a second _Change Set_{:.term} will be created. It is recommended that all changes within a _Change Set_{:.term} and, if applicable, across Change Sets be sorted in date-time order in the _orderedItems_{:.term} property with the earliest change in the set appearing first and most recent change in the set appearing last. For practical reasons, _Change Set_{:.term} and corresponding _Activities_{:.term} _MAY_{:.strong-term} be in ascending or descending order, but the order _MUST_{:.strong-term} be consistent within the _Entity Metadata Collection_{:.term}. Acknowledging not all implementations will store every change for an entity over time, _Entity Metadata Collection_{:.term} _MAY_{:.strong-term} provide feeds of only the last known metadata update for an entity. In these cases, because the _Entity Metadata Collection_{:.term} is not persistent (meaning _Ordered Collection Pages_{:.term} are overwritten, providing only the latest updates), _Activities_{:.term} within the _Entity Metadata Collection_{:.term} must include a date using _property_{:.term} because the page number can not be used to know the last _Activities_{:.term} processed by a consumer.
 
 It is _RECOMMENDED_{:.strong-term} that change sets be published on a regular schedule.  It is recognized that there are many factors that can impact this recommendation, including but not limited to, the volume of changes, the consistency of timing of changes, the tolerance of consumers for delays in notifications, resources for producing _Change Sets_{:.term}.
 
@@ -1145,7 +1145,7 @@ Create the change set:
 * set `"partOf"` property to use `entry_point_uri` for `"id"`
 * set `"prev"` property to use `prev_change_set_uri` for `"id"`
 * set `"totalItems"` property to the number of change activities that will be in this change set
-* for each change activity from oldest to newest, add it to the `"orderedItems"` property array
+* for each change activity from oldest to newest (preferred) or newest to oldest, add it to the `"orderedItems"` property array
   * set `"type"` property to the change type (e.g. Add, Remove, etc.)
   * set `"id"` property to the `change_activity_uri` for this change
   * set a date


### PR DESCRIPTION
Making clear preference is oldest to newest (seems most idiomatic), but leaving open the possibility that an implementation might choose newest to oldest (as long as they are consistent within a Stream).