### PR TITLE
Standardize spacing after full stops

### DIFF
--- a/docs/spec/api/0.1/recommendations_for_activity_streams.md
+++ b/docs/spec/api/0.1/recommendations_for_activity_streams.md
@@ -60,7 +60,7 @@ editors:
 
 ## Status of this Document
 
-_This is a very preliminary draft.  Expect considerable changes to this document._
+_This is a very preliminary draft. Expect considerable changes to this document._
 {:.todo}
 
 {:.no_toc}
@@ -98,16 +98,16 @@ QUESTIONS
 ## 1. Introduction
 {: #introduction}
 
-The primary purpose of this document is to establish a pattern that supports sharing changes to entities and their metadata curated by Entity Metadata Providers with the community of Entity Metadata Consumers (e.g. libraries, museums, galleries, archives).  Use of a consistent pattern allows for the creation of software tools for producing and consuming changes in entity metadata.
+The primary purpose of this document is to establish a pattern that supports sharing changes to entities and their metadata curated by Entity Metadata Providers with the community of Entity Metadata Consumers (e.g. libraries, museums, galleries, archives). Use of a consistent pattern allows for the creation of software tools for producing and consuming changes in entity metadata.
 
 The recommendations in this document leverage existing techniques, specifications, and tools in order to promote widespread adoption of an easy-to-implement service. The service describes changes to entity metadata and the location of those resources to harvest. Content providers can implement this API to enable notifications of change and incremental cache updates.
 
 ### 1.1. Objectives and Scope
 {: #objectives-and-scope}
 
-The objective of these recommendations is to provide a machine to machine API that provides the information needed to describe changes to entity metadata across the lifecycle of an entity.  The intended audiences are Entity Metadata Provides who curate aggregations of entity metadata within an area of interest, Entity Metadata Consumers who use the entity metadata, and Entity Metadata Developers who create applications and tools that help consumers connect to entity metadata from providers. While this work may benefit others wanting to express changes in data, the objective of the API is to specify an interoperable solution that best and most easily fulfills the need to express and process changes in entity metadata within the community of participating organizations.
+The objective of these recommendations is to provide a machine to machine API that provides the information needed to describe changes to entity metadata across the lifecycle of an entity. The intended audiences are Entity Metadata Provides who curate aggregations of entity metadata within an area of interest, Entity Metadata Consumers who use the entity metadata, and Entity Metadata Developers who create applications and tools that help consumers connect to entity metadata from providers. While this work may benefit others wanting to express changes in data, the objective of the API is to specify an interoperable solution that best and most easily fulfills the need to express and process changes in entity metadata within the community of participating organizations.
 
-The discovery of changes to entity metadata requires a consistent and well understood pattern for entity metadata providers to publish lists of links to entities that have metadata changes and details on changes that have occurred.  Changes include newly available entities with metadata, removed entities, as well as, changes to entities and their metadata.  This allows a baseline implementation of change management systems that process the list of changes. 
+The discovery of changes to entity metadata requires a consistent and well understood pattern for entity metadata providers to publish lists of links to entities that have metadata changes and details on changes that have occurred. Changes include newly available entities with metadata, removed entities, as well as, changes to entities and their metadata. This allows a baseline implementation of change management systems that process the list of changes. 
 
 This process can be optimized by allowing the content providers to publish changes in chronological order including descriptions of how their content has changed, enabling consuming systems to retrieve only the resources that have been modified since they were last retrieved. Finally, for rapid synchronization, a system of notifications pushed from the publisher to a set of subscribers can reduce the amount of effort required to constantly poll multiple sources to see if anything has changed.
 
@@ -119,32 +119,32 @@ Work that is out of scope of this API includes the recommendation or creation of
 ### 1.2. Use Cases
 {: #use-cases}
 
-Three primary use cases were identified that drive the recommendations in this document.  The use cases are listed from a simple change document with minimal information to a fully defined change document including details about what changed. 
+Three primary use cases were identified that drive the recommendations in this document. The use cases are listed from a simple change document with minimal information to a fully defined change document including details about what changed. 
 
 #### 1.2.1. Notifications
 {: #notifications}
 
-Entity metadata consumers want to be notified of any modifications or deletions for entities on their interest list, as well as new entities.  This allows for a comparison between the consumer's list and the producer's notification list of modified and deleted entities.  For any that overlap, the consumer will take additional actions if needed.
+Entity metadata consumers want to be notified of any modifications or deletions for entities on their interest list, as well as new entities. This allows for a comparison between the consumer's list and the producer's notification list of modified and deleted entities. For any that overlap, the consumer will take additional actions if needed.
 
-To address this use case, the provider creates and makes available a list of the URIs for any new, modified, or deleted entities.  The consumer will need to take additional actions to identify specific changes to entities of interest.
+To address this use case, the provider creates and makes available a list of the URIs for any new, modified, or deleted entities. The consumer will need to take additional actions to identify specific changes to entities of interest.
 
 #### 1.2.2. Local Cache of Labels
 {: #local-cache-of-labels}
 
-Entity metadata consumers persist references to entity metadata by saving the URI as part of their local datastore.  URIs may not be understandable to application users.  In order to be able to display a human readable label, a label may be retrieved from the producer's datastore by dereferencing the URI.  For performance reasons, the label is generally cached in the local datastore to avoid having to fetch the label every time the entity reference is displayed to an end user.  If the label changes in the producer's datastore, the consumer would like to update the local cache of the label.
+Entity metadata consumers persist references to entity metadata by saving the URI as part of their local datastore. URIs may not be understandable to application users. In order to be able to display a human readable label, a label may be retrieved from the producer's datastore by dereferencing the URI. For performance reasons, the label is generally cached in the local datastore to avoid having to fetch the label every time the entity reference is displayed to an end user. If the label changes in the producer's datastore, the consumer would like to update the local cache of the label.
 
-To address this use case, the provider creates and makes available a list of URIs and their new labels.  The consumer can compare the list of URIs with those stored in the local application and update the cached labels.
+To address this use case, the provider creates and makes available a list of URIs and their new labels. The consumer can compare the list of URIs with those stored in the local application and update the cached labels.
 
-__Additional Cached Metadata__<br>In some cases, additional metadata is also cached as part of the external reference, but this is less common.  Verification of the additional metadata may require the consumer to take additional actions.
+__Additional Cached Metadata__<br>In some cases, additional metadata is also cached as part of the external reference, but this is less common. Verification of the additional metadata may require the consumer to take additional actions.
 {: .warning}
 
 
 #### 1.2.3. Local Cache of Full Dataset
 {: #local-cache-of-full-dataset}
 
-A consumer may decide to make a full cache of a dataset of entity metadata.  This is commonly done for several reasons including, but not limited to, increased control over uptime, throughput, and indexing for search.  The cache needs to stay in sync with the source dataset as near to real time as is possible using incremental updates.
+A consumer may decide to make a full cache of a dataset of entity metadata. This is commonly done for several reasons including, but not limited to, increased control over uptime, throughput, and indexing for search. The cache needs to stay in sync with the source dataset as near to real time as is possible using incremental updates.
 
-To address this use case, the provider creates and makes available a dated list of all new, modified, and deleted entities along with specifics about how the entities have changed.  The consumer can process a stream of change documents, from oldest to newest, that was published since their last incremental update.  Specific details about each change can be used to update the local cache.
+To address this use case, the provider creates and makes available a dated list of all new, modified, and deleted entities along with specifics about how the entities have changed. The consumer can process a stream of change documents, from oldest to newest, that was published since their last incremental update. Specific details about each change can be used to update the local cache.
 
 ### 1.3. Terminology
 {: #terminology}
@@ -155,14 +155,14 @@ To address this use case, the provider creates and makes available a dated list 
 TODO:  Maybe put a list of providers in an appendix instead of here.
 {:.todo}
 
-* Entity Metadata Provider: An organization that collects, curates, and provides access to metadata about entities within an area of interest.  The Library of Congress maintains several [collections](https://id.loc.gov/), including but not limited to, Library Subject Headings, Name Authority, Genres/Form Terms.  The Getty maintains several [vocabularies](https://www.getty.edu/research/tools/vocabularies/index.html).  There are many other providers.
-* Entity Metadata Consumer: Any institution that references or caches entity metadata from a provider.  The use cases driving the recommendations were created from libraries, museums, galleries, and archives.
-* Entity Metadata Developer: Software developers that create applications and tools that help consumers connect to entity metadata from providers.  The developer may be associated with the provider, consumer, or a third party.
+* Entity Metadata Provider: An organization that collects, curates, and provides access to metadata about entities within an area of interest. The Library of Congress maintains several [collections](https://id.loc.gov/), including but not limited to, Library Subject Headings, Name Authority, Genres/Form Terms. The Getty maintains several [vocabularies](https://www.getty.edu/research/tools/vocabularies/index.html). There are many other providers.
+* Entity Metadata Consumer: Any institution that references or caches entity metadata from a provider. The use cases driving the recommendations were created from libraries, museums, galleries, and archives.
+* Entity Metadata Developer: Software developers that create applications and tools that help consumers connect to entity metadata from providers. The developer may be associated with the provider, consumer, or a third party.
 
 #### 1.3.2. Terms about Entities
 {: #terms-about-entities}
 
-* Entity Metadata Collection: Entities can be grouped based on varying criteria (e.g. subject headings, names, thesaurus, controlled vocabulary).  The term Entity Metadata Collection will be used as a generic representation of these grouping regardless of type.
+* Entity Metadata Collection: Entities can be grouped based on varying criteria (e.g. subject headings, names, thesaurus, controlled vocabulary). The term Entity Metadata Collection will be used as a generic representation of these grouping regardless of type.
 * Authority: 
 * Controlled Vocabulary: 
 * Collection: 
@@ -200,9 +200,9 @@ The proposed structure for expressing change of entity metadata over time uses t
 Reference:  [Ordered Collection][org-w3c-activitystreams-coretype-orderedcollection] in the [Activity Stream specification][org-w3c-activitystreams]
 {:.reference}
 
-Each _Entity Metadata Collection_{:.term} _MUST_{:.strong-term} have at least one Entry Point.  It _MAY_{:.strong-term} have multiple Entry Points to satisfy different use cases.  For example, one Entry Point may provide detailed changes to support incremental updates of a full cache and a second may only provide notifications of primary label changes.
+Each _Entity Metadata Collection_{:.term} _MUST_{:.strong-term} have at least one Entry Point. It _MAY_{:.strong-term} have multiple Entry Points to satisfy different use cases. For example, one Entry Point may provide detailed changes to support incremental updates of a full cache and a second may only provide notifications of primary label changes.
 
-The Entry Point _MUST_{:.strong-term} be implemented as an _Ordered Collection_{:.term} following the definition in the Activity Stream specification.  The key points are repeated here with examples specific to Entity Metadata Management.
+The Entry Point _MUST_{:.strong-term} be implemented as an _Ordered Collection_{:.term} following the definition in the Activity Stream specification. The key points are repeated here with examples specific to Entity Metadata Management.
 
 #### FULL EXAMPLE for Entry Point:
 
@@ -245,11 +245,11 @@ Reference: [JSON-LD scoped context][org-w3c-json-ld-scoped-contexts]
 
 The @context URL _MUST_{:.strong-term} point to a JSON-LD context which, in its simplest form, maps terms to IRIs and can define a context for values of properties. 
 
-_Entity Metadata Management_{:.term} activity streams _MUST_{:.strong-term} include @context at each level in order to conform to [JSON-LD][org-w3c-json-ld] syntax.  The _Entity Metadata Management_{:.term} [context definition][emm-context-api-01] includes information for all levels, and as such, the same context definition is used for all levels. 
+_Entity Metadata Management_{:.term} activity streams _MUST_{:.strong-term} include @context at each level in order to conform to [JSON-LD][org-w3c-json-ld] syntax. The _Entity Metadata Management_{:.term} [context definition][emm-context-api-01] includes information for all levels, and as such, the same context definition is used for all levels. 
 
 Implementations may augment the provided @context with additional @context definitions but must not override or change the normative context of the _Activity Stream_{:.term} context or the _Entity Metadata Management_{:.term} context. Implementations may also use additional properties and values not defined in the JSON-LD @context with the understanding that any such properties will likely be unsupported and ignored by consuming implementations that use the standard JSON-LD algorithms.
 
-The @context _SHOULD_ be `"https://ld4.github.io/entity_metadata_management/api/0.1/activitystreams-extensions"`, or an extension of this definition.  The _Entity Metadata Management_{:.term} context is an extension of the _Activity Streams_{:.term} [context][org-w3c-activitystreams-context-definition].
+The @context _SHOULD_ be `"https://ld4.github.io/entity_metadata_management/api/0.1/activitystreams-extensions"`, or an extension of this definition. The _Entity Metadata Management_{:.term} context is an extension of the _Activity Streams_{:.term} [context][org-w3c-activitystreams-context-definition].
 
 TODO: Link to EMM context once it is created.
 {:.todo}
@@ -262,7 +262,7 @@ Reference:  [summary][org-w3c-activitystreams-property-summary] property definit
 
 The summary is a natural language summarization of the purpose of the _Entry Point_{:.term}
 
-The _Entry Point_{:.term} _SHOULD_{:.strong-term} have a _summary_{:.term} property.  For an _Entry Point_{:.term}, the summary _CAN_{:.strong-term} be a brief description of the _Entity Metadata Collection_{:.term} in which the described changes occurred.  If there are multiple entry points to the same collection, it is _RECOMMENDED_{:.strong-term} that the summary include information that distinguishes each entry point from the others.
+The _Entry Point_{:.term} _SHOULD_{:.strong-term} have a _summary_{:.term} property. For an _Entry Point_{:.term}, the summary _CAN_{:.strong-term} be a brief description of the _Entity Metadata Collection_{:.term} in which the described changes occurred. If there are multiple entry points to the same collection, it is _RECOMMENDED_{:.strong-term} that the summary include information that distinguishes each entry point from the others.
 
 ```json-doc
 { "summary": "My Authoritity - Notifications of Change" }
@@ -280,7 +280,7 @@ Reference:  [type][org-w3c-activitystreams-property-type] property definition
 
 The type property identifies the Activity Stream type for the _Entry Point_{:.term}.
 
-The _Entry Point_{:.term} _MUST_{:.strong-term} have a _type_{:.term} property.  The value _MUST_{:.strong-term} be `"OrderedCollection"`.
+The _Entry Point_{:.term} _MUST_{:.strong-term} have a _type_{:.term} property. The value _MUST_{:.strong-term} be `"OrderedCollection"`.
 
 ```json-doc
 { "type": "OrderedCollection" }
@@ -308,7 +308,7 @@ Reference:  [first][org-w3c-activitystreams-property-url] property definition
 
 The url property identifies one or more links to representations of the _Entity Metadata Collection_{:.term}
 
-The _Entry Point_{:.term} _MAY_{:.strong_term} have one or more URLs listed.  If there are multiple URLs, the value of the url property will be an array.  A common value for the url property is a link to the full download for the collection.
+The _Entry Point_{:.term} _MAY_{:.strong_term} have one or more URLs listed. If there are multiple URLs, the value of the url property will be an array. A common value for the url property is a link to the full download for the collection.
 
 ```json-doc
 { "url": "https://my.authority/2021-01-01/full_download" }
@@ -368,7 +368,7 @@ Reference:  [totalItems][org-w3c-activitystreams-property-totalitems] property d
 
 The count of all _Entity Change Notifications_{:.term} across all _Change Sets_{:.term} in the _Entry Point_{:term} for the _Entity Collection_{:.term}.
 
-The _Entry Point_{:.term} _MAY_{:.strong-term} have a _totalItems_{:.term} property.  If included, the value _MUST_{:.strong-term} be an integer, and it _SHOULD_{:.strong-term} be the cumulative count of _Entity Change Notifications_{:.term} across all _Change_sets_{:.term}.
+The _Entry Point_{:.term} _MAY_{:.strong-term} have a _totalItems_{:.term} property. If included, the value _MUST_{:.strong-term} be an integer, and it _SHOULD_{:.strong-term} be the cumulative count of _Entity Change Notifications_{:.term} across all _Change_sets_{:.term}.
 
 ```json-doc
 {
@@ -383,11 +383,11 @@ The _Entry Point_{:.term} _MAY_{:.strong-term} have a _totalItems_{:.term} prope
 Reference:  [Ordered Collection Page][org-w3c-activitystreams-coretype-orderedcollectionpage] in the [Activity Stream specification][org-w3c-activitystreams]
 {:.reference}
 
-Each time a set of changes is published, changes _MUST_{:.strong-term} be released in at least one _Change Set_{:.term}.  Changes _MAY_{:.strong-term} be published across multiple _Change Sets_{:.term}.  For example, a site may decide that each _Change Set_{:.term} will have at most 50 changes and if that maximum is exceeded during the release time period, then a second _Change Set_{:.term} will be created. All changes within a _Change Set_{:.term} and, if applicable, across  Change Sets _MUST_{:.strong-term} be sorted in date-time order in the _orderedItems_{:.term} property with the earliest change in the set appearing first and most recent change in the set appearing last.
+Each time a set of changes is published, changes _MUST_{:.strong-term} be released in at least one _Change Set_{:.term}. Changes _MAY_{:.strong-term} be published across multiple _Change Sets_{:.term}. For example, a site may decide that each _Change Set_{:.term} will have at most 50 changes and if that maximum is exceeded during the release time period, then a second _Change Set_{:.term} will be created. All changes within a _Change Set_{:.term} and, if applicable, across  Change Sets _MUST_{:.strong-term} be sorted in date-time order in the _orderedItems_{:.term} property with the earliest change in the set appearing first and most recent change in the set appearing last.
 
-It is _RECOMMENDED_{:.strong-term} that change sets be published on a regular schedule.  It is recognized that there are many factors that can impact this recommendation, including but not limited to, the volume of changes, the consistency of timing of changes, the tolerance of consumers for delays in notifications, resources for producing _Change Sets_{:.term}.
+It is _RECOMMENDED_{:.strong-term} that change sets be published on a regular schedule. It is recognized that there are many factors that can impact this recommendation, including but not limited to, the volume of changes, the consistency of timing of changes, the tolerance of consumers for delays in notifications, resources for producing _Change Sets_{:.term}.
 
-_Change Sets_{:.term} _MUST_{:.strong-term} be implemented as an _Ordered Collection Page_{:.term} following the definition in the Activity Stream specification.  The key points are repeated here with examples specific to Entity Metadata Management.
+_Change Sets_{:.term} _MUST_{:.strong-term} be implemented as an _Ordered Collection Page_{:.term} following the definition in the Activity Stream specification. The key points are repeated here with examples specific to Entity Metadata Management.
 
 #### FULL EXAMPLE for Change Set:
 
@@ -457,7 +457,7 @@ NOTE: See [Entity Change Notification](#entity-change-notification) under [Entit
 ## 4. Entity Level Structures
 {: #entity-level-structures}
 
-The structures described in this section are used in the _ordered_items_{:.term} property of of the [Change Set](#change-set).  The level of detail in the _ordered_items_{:.term} depends on the use case being addressed.  The [Notifications](#notifications) use case can be addressed by the [Entity Change Notification](#entity-change-notification).  The [Local Cache of Labels](#local-cache-of-labels) and [Local Cache of Full Dataset](#local-cache-of-full-dataset) use cases can be addressed by also including an [Entity Patch](#entity-patch).
+The structures described in this section are used in the _ordered_items_{:.term} property of of the [Change Set](#change-set). The level of detail in the _ordered_items_{:.term} depends on the use case being addressed. The [Notifications](#notifications) use case can be addressed by the [Entity Change Notification](#entity-change-notification). The [Local Cache of Labels](#local-cache-of-labels) and [Local Cache of Full Dataset](#local-cache-of-full-dataset) use cases can be addressed by also including an [Entity Patch](#entity-patch).
 
 ### 4.1. Entity Change Notification
 {: #entity-change-notification}
@@ -468,12 +468,12 @@ Reference:  [Activity][org-w3c-activitystreams-coretype-activity] in the [Activi
 QUESTION: To tie the language we are using closer to the Activity Stream, should we rename Entity Change Notification to Entity Change Activity?
 {:.todo}
 
-QUESTION: Based on review of LOC activity stream and how it can be processed in its current state to allow processing to update a full cache, it brings into question whether we should recommend the RDF Patch approach.  Removing RDF Patch will reduce complexity for the Producer and may increase accuracy of consumed data.  See Consumer Processing for a description of the process.
+QUESTION: Based on review of LOC activity stream and how it can be processed in its current state to allow processing to update a full cache, it brings into question whether we should recommend the RDF Patch approach. Removing RDF Patch will reduce complexity for the Producer and may increase accuracy of consumed data. See Consumer Processing for a description of the process.
 {:.todo}
 
-A change to Entity Metadata _MUST_{:.strong-term} be described in an _Entity Change Notification_{:.term}.  The notification _MUST_{:.strong-term} provide information about the type of change and _SHOULD_{:.strong-term} provide links that facilitate the consumer gathering additional information from the source dataset.  This level is sufficient to address the Notifications use case.
+A change to Entity Metadata _MUST_{:.strong-term} be described in an _Entity Change Notification_{:.term}. The notification _MUST_{:.strong-term} provide information about the type of change and _SHOULD_{:.strong-term} provide links that facilitate the consumer gathering additional information from the source dataset. This level is sufficient to address the Notifications use case.
 
-_Entity Change Notifications_{:.term} _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [definition](https://www.w3.org/TR/activitystreams-vocabulary/#activity) in the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples specific to Entity Metadata Management.
+_Entity Change Notifications_{:.term} _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [definition](https://www.w3.org/TR/activitystreams-vocabulary/#activity) in the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples specific to Entity Metadata Management.
 
 #### FULL EXAMPLE for Entity Change Notification:
 
@@ -503,7 +503,7 @@ _Entity Change Notifications_{:.term} _MUST_{:.strong-term} be implemented as an
 }
 ```
 
-Properties shared across all _Entity Change Notification_{:.term} types are described here.  If a specific notification type handles a property different, it will be described with that notification type in section [Types of Change](#types-of-change).
+Properties shared across all _Entity Change Notification_{:.term} types are described here. If a specific notification type handles a property different, it will be described with that notification type in section [Types of Change](#types-of-change).
 
 <a id="entity-change-notification-context" class="anchor-definition">
 __@context__
@@ -516,9 +516,9 @@ __summary__
 Reference:  [summary][org-w3c-activitystreams-property-summary] property definition
 {:.reference}
 
-For _Entity Change Notification_{:.term}, the summary is a brief description of the change to entity metadata that the notification represents.  It is _RECOMMENDED_{:.strong-term} that a summary be included and that it reference the type of change (e.g. "Add entity") and the entity being changed (e.g. "subject Science").  
+For _Entity Change Notification_{:.term}, the summary is a brief description of the change to entity metadata that the notification represents. It is _RECOMMENDED_{:.strong-term} that a summary be included and that it reference the type of change (e.g. "Add entity") and the entity being changed (e.g. "subject Science").
 
-There are a limited set of types of change.  See [Types of Change](#type-of-change) section for a list of types and example summaries for each.  Identification of the entity will vary depending on the data represented in the _Entity Metadata Collection_{:.term}.
+There are a limited set of types of change. See [Types of Change](#type-of-change) section for a list of types and example summaries for each. Identification of the entity will vary depending on the data represented in the _Entity Metadata Collection_{:.term}.
 
 ```json-doc
 { "summary": "Add entity for subject Science" }
@@ -532,7 +532,7 @@ Reference:  [type][org-w3c-activitystreams-property-type] property definition
 
 Each _Entity Change Notification_{:.term} _MUST_{:.strong-term} have a _type_{:.term} property.
 
-The type is the one of a set of predefined _Entity Change Notification_{:.term} activity types.  See [Types of Change](#type-of-change) section for a list of types and recommendations for the value of type for each activity type.
+The type is the one of a set of predefined _Entity Change Notification_{:.term} activity types. See [Types of Change](#type-of-change) section for a list of types and recommendations for the value of type for each activity type.
 
 ```json-doc
 { "type": "Create" }
@@ -560,7 +560,7 @@ Reference:  [partOf][org-w3c-activitystreams-property-partof] property definitio
 
 The _partOf_ property identifies the _Change Set_{:.term} in which this notification was published.
 
-Each _Entity Change Notification_{:.term} _MUST_{:.strong-term} use the _partOf_ property if referring back to the _Change Set_{:.term} that includes this notification.  The value _MUST_{:.strong-term} be a string and it _MUST_{:.strong-term} be an HTTP(S) URI. The JSON representation of the _Change Set_{:.term} publishing this notification _MUST_{:.strong-term} be available at the URI.
+Each _Entity Change Notification_{:.term} _MUST_{:.strong-term} use the _partOf_ property if referring back to the _Change Set_{:.term} that includes this notification. The value _MUST_{:.strong-term} be a string and it _MUST_{:.strong-term} be an HTTP(S) URI. The JSON representation of the _Change Set_{:.term} publishing this notification _MUST_{:.strong-term} be available at the URI.
 
 ```json-doc
 "partOf": {
@@ -604,7 +604,7 @@ To support the [Local Cache of Labels](#local-cache-of-labels) or the [Local Cac
 ## 5. Types of Change
 {: #types-of-change}
 
-All {Entity Change Notifications_{:.term} have a core set of properties that are described in the [Entity Change Notification](#entity-change-notification) section.  Some properties are specific to the _Types of Change_.  This section provides examples and descriptions of the _Entity Change Notification_{:.term} and _Entity Patch_{:.term} for each type of change.  They also describe differences between similar Activity Types (e.g. _Create_{:.term} vs. _Add_{:.term}).
+All {Entity Change Notifications_{:.term} have a core set of properties that are described in the [Entity Change Notification](#entity-change-notification) section. Some properties are specific to the _Types of Change_. This section provides examples and descriptions of the _Entity Change Notification_{:.term} and _Entity Patch_{:.term} for each type of change. They also describe differences between similar Activity Types (e.g. _Create_{:.term} vs. _Add_{:.term}).
 
 ### 5.1. New Entity
 {: #new-entity}
@@ -617,7 +617,7 @@ Reference: [create][org-w3c-activitystreams-activity-create] activity definition
 
 A new entity _SHOULD_{:.strong-term} have an [Entity Change Notification](#entity-change-notification) with a _type_{:.term} of either _"Create"_{:.term} or _"Add"_{:.term}.
 
-A new entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Create type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-create) or the [Add type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-add) in the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples specific to Entity Metadata Management.
+A new entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Create type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-create) or the [Add type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-add) in the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples specific to Entity Metadata Management.
 
 #### Create vs. Add
 
@@ -625,9 +625,9 @@ An entity appearing in an _Entry Point_{:.term} stream for the first time _MUST_
 
 _Create_{:.term} _SHOULD_{:.strong-term} be used when the entity is new in the source dataset.
 
-_Add_{:.term} _SHOULD_{:.strong-term} be used when the entity exists in the source dataset, but was previously not available through the _Entry Point_{:.term} and now is being made available in the stream.  Situations where this might happen include, but are not limited to, change in permissions, end of an embargo, temporary removal and now being made available again.  
+_Add_{:.term} _SHOULD_{:.strong-term} be used when the entity exists in the source dataset, but was previously not available through the _Entry Point_{:.term} and now is being made available in the stream. Situations where this might happen include, but are not limited to, change in permissions, end of an embargo, temporary removal and now being made available again.
 
-A new _Entry Point_{:.term} _MAY_{:.strong-term} choose to populate the stream with all existing entities.  In this case, the initial population of the stream with all existing entities _SHOULD_{:.strong-term} use _Add_{:.term}.
+A new _Entry Point_{:.term} _MAY_{:.strong-term} choose to populate the stream with all existing entities. In this case, the initial population of the stream with all existing entities _SHOULD_{:.strong-term} use _Add_{:.term}.
 
 #### EXAMPLE Entity Change Notification for Create
 
@@ -664,7 +664,7 @@ __summary__
 Reference:  [summary][org-w3c-activitystreams-property-summary] property definition
 {:.reference}
 
-A summary is a brief description of a change to entity metadata.  It is _RECOMMENDED_{:.strong-term} that a summary be included and that it reference the type of change and the entity being changed.
+A summary is a brief description of a change to entity metadata. It is _RECOMMENDED_{:.strong-term} that a summary be included and that it reference the type of change and the entity being changed.
 
 ```json-doc
 { "summary": "Add entity for subject Science" }
@@ -677,7 +677,7 @@ Reference:  [type][org-w3c-activitystreams-property-type] property definition
 
 The type is the one of a set of predefined _Entity Change Notification_{:.term} activity types.
 
-Each _Entity Change Notification_{:.term} _MUST_{:.strong-term} have a _type_{:.term} property.  For a notification of a newly available entity, the value _SHOULD_{:.strong-term} be one of either `"Create"` or `"Add"`.
+Each _Entity Change Notification_{:.term} _MUST_{:.strong-term} have a _type_{:.term} property. For a notification of a newly available entity, the value _SHOULD_{:.strong-term} be one of either `"Create"` or `"Add"`.
 
 ```json-doc
 { "type": "Create" }
@@ -749,7 +749,7 @@ Complete Example
 
 An updated entity _SHOULD_{:.strong-term} have an [Entity Change Notification](#entity-change-notification) with a _type_{:.term} of _"Update"_{:.term}.
 
-An updated entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Update type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-update)in the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples specific to Entity Metadata Management.
+An updated entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Update type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-update)in the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples specific to Entity Metadata Management.
 
 EXAMPLE Entity Change Notification for Update
 
@@ -806,7 +806,7 @@ It is _RECOMMENDED_{:.strong-term} that entities be marked as _Deprecated_{:.ter
 
 An entity that has been fully deleted from the source dataset _SHOULD_{:.strong-term} have an [Entity Change Notification](#entity-change-notification) with a _type_{:.term} of _"Delete"_{:.term} or _"Remove"_{:.term}.
 
-A deleted entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Delete type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-delete) or the [Remove type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-remove) in the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples specific to Entity Metadata Management.
+A deleted entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Delete type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-delete) or the [Remove type definition](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-remove) in the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples specific to Entity Metadata Management.
 
 EXAMPLE Entity Change Notification for Delete
 
@@ -866,7 +866,7 @@ EXAMPLE Entity Patch for Delete
 
 An entity that has been deprecated _SHOULD_{:.strong-term} have an [Entity Change Notification](#entity-change-notification) with a _type_{:.term} of _"Deprecate"_{:.term}.
 
-A deprecated entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Deprecate extended type definition](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit#heading=h.u6iw3ncw6945)  in the [Entity Metadata Management extension](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit) to the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples.
+A deprecated entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Deprecate extended type definition](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit#heading=h.u6iw3ncw6945)  in the [Entity Metadata Management extension](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit) to the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples.
 
 EXAMPLE Entity Change Notification for Deprecate
 
@@ -924,7 +924,7 @@ EXAMPLE Entity Change Notification for Deprecate
 
 An entity that has been split into two or more new entities _SHOULD_{:.strong-term} have an [Entity Change Notification](#entity-change-notification) with a _type_{:.term} of _"Split"_{:.term}.
 
-A split entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Split extended type definition](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit#heading=h.jlx8rz32qnvm)  in the [Entity Metadata Management extension](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit) to the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples.
+A split entity _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Split extended type definition](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit#heading=h.jlx8rz32qnvm)  in the [Entity Metadata Management extension](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit) to the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples.
 
 EXAMPLE Entity Change Notification for Split
 
@@ -996,7 +996,7 @@ EXAMPLE Entity Change Notification for Split
 
 Entities that has been merged into one new entity _SHOULD_{:.strong-term} have an [Entity Change Notification](#entity-change-notification) with a _type_{:.term} of _"Merge"_{:.term}.
 
-A change that merges entities _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Merge extended type definition](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit#heading=h.e7zppj5vycms)  in the [Entity Metadata Management extension](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit) to the [Activity Stream specification][org-w3c-activitystreams].  The key points are repeated here with examples.
+A change that merges entities _MUST_{:.strong-term} be implemented as an _Activity_{:.term} following the [Merge extended type definition](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit#heading=h.e7zppj5vycms)  in the [Entity Metadata Management extension](https://docs.google.com/document/d/1eiFANJvR6cYE3Tx3cTsLhDO_BxZFr7NKPrQnBPh48rk/edit) to the [Activity Stream specification][org-w3c-activitystreams]. The key points are repeated here with examples.
 
 EXAMPLE Entity Change Notification for Merge
 
@@ -1097,12 +1097,12 @@ Reference:  [updated][org-w3c-activitystreams-property-updated] property definit
 Reference:  [deleted][org-w3c-activitystreams-property-deleted] property definition
 {:.reference}
 
-TODO: Add discussion and reasoning for when to use each type of date.  Still need to determine our recommendations around dates.
+TODO: Add discussion and reasoning for when to use each type of date. Still need to determine our recommendations around dates.
 {:.todo}
 
 ### For Notifications
 
-QUESTION: Should each place that talks about a part of the feed include a link into the examples of that part?  For example, include link to Entry Point in the instructions to create it; a link to a Change Set when it is created; etc.  OR as is done here, a link at the top of the section to the entry point for the use case being described.
+QUESTION: Should each place that talks about a part of the feed include a link into the examples of that part?  For example, include link to Entry Point in the instructions to create it; a link to a Change Set when it is created; etc. OR as is done here, a link at the top of the section to the entry point for the use case being described.
 {:.todo}
 
 [Live Example of Notifications Entry Point][emm-change-api-example-notifications]
@@ -1126,7 +1126,7 @@ Record information about the entity and the changes
 * type of change (e.g. Add, Remove, Update, Deprecate, Split, Merge)
 * RDF patch steps describing what was changed (optional, see note)
 
-NOTE: Storing RDF patch steps is optional for Notifications.  All changes are required for Incremental Updates and changes to labels are required for Label Changes.
+NOTE: Storing RDF patch steps is optional for Notifications. All changes are required for Incremental Updates and changes to labels are required for Label Changes.
 {:.info}
 
 #### When ready to publish a change set
@@ -1215,7 +1215,7 @@ Create an RDF patch for each change activity:
 
 ### 7.1 Example consuming Library of Congress Activity Stream
 
-_CAUTION: This section is under construction.  This section may or may not be removed from the final draft, in lieu of, a section that is a general example based off the final recommendations._
+_CAUTION: This section is under construction. This section may or may not be removed from the final draft, in lieu of, a section that is a general example based off the final recommendations._
 {:.todo}
 
 Library of Congress provides an activity stream for several authorities (e.g. names, genre/forms, subjects, etc.).


### PR DESCRIPTION
There is a mix of one and two spaces after full stops at the end of sentences. This commit standardizes to a single space after each full stop.