### PR TITLE
Remove IIIF history

### DIFF
--- a/docs/spec/api/disclaimer.md
+++ b/docs/spec/api/disclaimer.md
@@ -1,17 +1,12 @@
 ---
 title: "Specification Disclaimer"
-layout: spec
-tags: [change-api, license, disclaimer]
-cssversion: 2
-redirect_from:
-- /api/disclaimer.html
 ---
 
 ## License
 
 Specifications published by LD4 are made available using the [Creative Commons Attribution Required][cc-by] (CC-BY) license.
 
-Please note that this license forbids the assertion, implied or explicit, that IIIF, the Consortium, the Community or any of its members endorses or is any way associated with uses of the specifications or implementations thereof.
+Please note that this license forbids the assertion, implied or explicit, that the LD4 Community or any of its members endorses or is any way associated with uses of the specifications or implementations thereof.
 
 Supporting JSON files such as JSON-LD context documents, examples, and test fixtures are placed in the public domain using the [CC0 Public Domain Dedication][cc0].
 
@@ -28,5 +23,3 @@ This disclaimer is the same as used by the [W3C][w3c] for its specifications.
 [cc-by]: http://creativecommons.org/licenses/by/4.0/ "Creative Commons &mdash; Attribution 4.0 International"
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0/ "CC0 Public Domain Dedication"
 [w3c]: http://www.w3.org/Consortium/Legal/2015/doc-license
-
-{% include api/acronyms.md %}


### PR DESCRIPTION
I'm not 100% sure whether the `docs/spec/api/disclaimer.md` file is required. If it is then it certainly shouldn't reference the IIIF (from where it was copied I assume) so this PR fixes that.