### PR TITLE
Fix typo "authoritity"

### DIFF
--- a/docs/spec/api/0.1/recommendations_for_activity_streams.md
+++ b/docs/spec/api/0.1/recommendations_for_activity_streams.md
@@ -275,7 +275,7 @@ The _Entry Point_{:.term} _SHOULD_{:.strong-term} have a _summary_{:.term} prope
 ```
 
 ```json-doc
-{ "summary": "My Authoritity - Incremental Updates from 2022-01-01 Full Download" }
+{ "summary": "My Authority - Incremental Updates from 2022-01-01 Full Download" }
 ```
 
 <a id="entry-point-type" class="anchor-definition">

--- a/docs/spec/api/0.1/recommendations_for_activity_streams.md
+++ b/docs/spec/api/0.1/recommendations_for_activity_streams.md
@@ -271,7 +271,7 @@ The _Entry Point_{:.term} _SHOULD_{:.strong-term} have a _summary_{:.term} prope
 
 
 ```json-doc
-{ "summary": "My Authoritity - Notifications of Change" }
+{ "summary": "My Authority - Notifications of Change" }
 ```
 
 ```json-doc


### PR DESCRIPTION
Trivial typo fix: authoritity -> authority