### PR TITLE
Use either backticks of terms for OrderedCollection[Page]

### DIFF
--- a/docs/0.1/index.md
+++ b/docs/0.1/index.md
@@ -195,7 +195,7 @@ Implementations _MAY_{:.strong-term} include additional extension contexts. Exte
 Reference: [OrderedCollection][org-w3c-activitystreams-coretype-orderedcollection] description
 {:.reference}
 
-An _Entry Point_{:.term} is an Activity Streams Ordered Collection resource identifying a dataset whose changes are published using the Activity Streams vocabulary with Entity Metadata Management enhancements. It provides pointers to one or more Change Sets.
+An _Entry Point_{:.term} is an Activity Streams _OrderedCollection_{:.term} resource identifying a dataset whose changes are published using the Activity Streams vocabulary with Entity Metadata Management enhancements. It provides pointers to one or more Change Sets.
 
 The _Entry Point_{:.term} _MUST_{:.strong-term} be implemented as an _OrderedCollection_{:.term} following the definition in the Activity Stream specification. The key points are repeated here with examples specific to Entity Metadata Management.
 
@@ -347,7 +347,7 @@ The _Entry Point_{:.term} _MAY_{:.strong-term} have a `totalItems` property. If 
 Reference: [OrderedCollectionPage][org-w3c-activitystreams-coretype-orderedcollectionpage] description
 {:.reference}
 
-A _Change Set_{:.term} is an Activity Streams Ordered Collection Page resource identifying individual _Entity Change Activities_{:.term}, which are resources that have been created, modified, or deprecated. It may additionally help with identifying preceding or subsequent _Change Sets_{:.term} for automated crawling.
+A _Change Set_{:.term} is an Activity Streams _OrderedCollectionPage_{:.term} resource identifying individual _Entity Change Activities_{:.term}, which are resources that have been created, modified, or deprecated. It may additionally help with identifying preceding or subsequent _Change Sets_{:.term} for automated crawling.
 
 Each time a set of changes is published, changes _MUST_{:.strong-term} be released in at least one _Change Set_{:.term}. Changes _MAY_{:.strong-term} be published across multiple _Change Sets_{:.term}. For example, a site may decide that each _Change Set_{:.term} will have at most 50 changes and if that maximum is exceeded during the release time period, then a second _Change Set_{:.term} will be created.
 


### PR DESCRIPTION
Follow-on from #165 and @sfolsom's note:
> We have every combination \`\`, \_\_{:.term}, and unformatted.

This PR changes the change the one example of "Ordered Collection" and the one example of "Ordered Collection Page" to terms that are linked.