### PR TITLE
Clarify language in 4.1

### DIFF
--- a/docs/0.1/index.md
+++ b/docs/0.1/index.md
@@ -672,7 +672,7 @@ An entity appearing in an _Entry Point_{:.term} stream for the first time _MUST_
 
 `Add` _SHOULD_{:.strong-term} be used when the entity exists in the source dataset, but was previously not available through the _Entry Point_{:.term} and now is being made available in the stream. Situations where this might happen include, but are not limited to, change in permissions, end of an embargo, temporary removal and now being made available.
 
-A new _Entry Point_{:.term} _MAY_{:.strong-term} choose to populate the stream with all existing entities. In this case, the initial population of the stream with all existing entities _SHOULD_{:.strong-term} use `Add`.
+A new _Entry Point_{:.term} stream _MAY_{:.strong-term} choose to populate the stream with all existing entities from the source dataset. In this case, the initial population of the stream with all existing entities _SHOULD_{:.strong-term} use `Add`.
 
 #### Example Entity Change Activity excerpt for Create
 


### PR DESCRIPTION
Minor clarifying additions for consistency across this section.

In addition: I'm not sure I understand the difference(s) between the first line of 4.1 and the subsection "Create vs. Add" —

4.1 "A new entity SHOULD have an Entity Change Activity with a type of either Create or Add."

Create vs. Add: "An entity appearing in an Entry Point stream for the first time MUST use Activity type Create and/or Add."

Do both statements apply to "an entity appearing in an Entry Point stream for the first time"? If so, should 4.1 lead off with that phrase ("An entity appearing in an Entry Point stream for the first time"), as I initially misread it as being about entities new only to the stream (and not entities new to the dataset, as in the last scenario under Create vs. Add)?

(I'm also unclear about which specific scenarios in 4.1 "MUST" applies to; they all seem to be "SHOULD"s". But maybe I'm missing something here?)


